### PR TITLE
Potential fix for code scanning alert no. 3: Replacement of a substring with itself

### DIFF
--- a/components/group-dashboard-view.tsx
+++ b/components/group-dashboard-view.tsx
@@ -145,7 +145,7 @@ function ProviderCard({
                       type="button"
                       className={cn(
                         "flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium transition-colors hover:bg-muted",
-                        officialStatusMeta.color.replace('text-', 'text-')
+                        officialStatusMeta.color.replace('text-', 'bg-')
                       )}
                       onClick={
                         isCoarsePointer


### PR DESCRIPTION
Potential fix for [https://github.com/BingZi-233/check-cx/security/code-scanning/3](https://github.com/BingZi-233/check-cx/security/code-scanning/3)

To fix the problem, the substring replacement on line 148 should change from replacing `'text-'` with itself (`'text-'`) to replacing `'text-'` with `'bg-'`. This ensures that the color string meant for text is adapted for use as a background color class, matching the checked and correct usage on line 156. Only line 148 in `components/group-dashboard-view.tsx` needs to be changed. No new imports or method definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
