### PR TITLE
feat: add group tags and display them in the UI (Vibe Kanban)

### DIFF
--- a/components/dashboard-view.tsx
+++ b/components/dashboard-view.tsx
@@ -338,6 +338,19 @@ function GroupPanel({
               <h2 className="truncate text-lg font-bold tracking-tight text-foreground sm:text-2xl">
                 {group.displayName}
               </h2>
+              {group.tags && group.tags.length > 0 && (
+                <div className="flex flex-wrap items-center gap-1">
+                  {group.tags.map((tag) => (
+                    <Badge
+                      key={tag}
+                      variant="outline"
+                      className="rounded-full bg-background/50 px-2 py-0.5 text-[10px] font-semibold text-muted-foreground shadow-sm backdrop-blur-sm"
+                    >
+                      {tag}
+                    </Badge>
+                  ))}
+                </div>
+              )}
               {group.websiteUrl && (
                 <a
                   href={group.websiteUrl}
@@ -462,7 +475,7 @@ export function DashboardView({ initialData }: DashboardViewProps) {
         try {
           const parsed = JSON.parse(saved);
           if (Array.isArray(parsed)) {
-            setOrderedGroupNames(prev => {
+            setOrderedGroupNames(() => {
               const currentSet = new Set(initialData.groupedTimelines.map(g => g.groupName));
               // Filter out saved names that no longer exist, and add new ones
               const validSaved = parsed.filter(name => currentSet.has(name));

--- a/components/group-dashboard-view.tsx
+++ b/components/group-dashboard-view.tsx
@@ -367,6 +367,19 @@ export function GroupDashboardView({ groupName, initialData }: GroupDashboardVie
             <h1 className="max-w-2xl text-3xl font-extrabold leading-tight tracking-tight sm:text-5xl md:text-6xl">
               {displayName}
             </h1>
+            {data.tags && data.tags.length > 0 && (
+              <div className="flex flex-wrap items-center gap-1.5">
+                {data.tags.map((tag) => (
+                  <Badge
+                    key={tag}
+                    variant="outline"
+                    className="rounded-full bg-background/50 px-2.5 py-1 text-xs font-semibold text-muted-foreground shadow-sm backdrop-blur-sm"
+                  >
+                    {tag}
+                  </Badge>
+                ))}
+              </div>
+            )}
             {data.websiteUrl && (
               <a
                 href={data.websiteUrl}

--- a/lib/core/dashboard-data.ts
+++ b/lib/core/dashboard-data.ts
@@ -50,6 +50,7 @@ function groupTimelines(timelines: ProviderTimeline[], groupInfos: GroupInfoRow[
       groupName,
       displayName: groupName,
       websiteUrl: info?.website_url,
+      tags: info?.tags ?? null,
       timelines: groupTimelines.sort((a, b) =>
         a.latest.name.localeCompare(b.latest.name)
       ),

--- a/lib/core/group-data.ts
+++ b/lib/core/group-data.ts
@@ -26,6 +26,7 @@ export interface GroupDashboardData {
   pollIntervalMs: number;
   generatedAt: number;
   websiteUrl?: string | null;
+  tags?: string[] | null;
 }
 
 /**
@@ -116,9 +117,11 @@ export async function loadGroupDashboardData(
 
   // 获取分组信息（仅对有名分组）
   let websiteUrl: string | undefined | null;
+  let tags: string[] | undefined | null;
   if (!isTargetUngrouped) {
     const groupInfo = await getGroupInfo(targetGroupName);
     websiteUrl = groupInfo?.website_url;
+    tags = groupInfo?.tags ?? null;
   }
 
   return {
@@ -131,5 +134,6 @@ export async function loadGroupDashboardData(
     pollIntervalMs,
     generatedAt,
     websiteUrl,
+    tags,
   };
 }

--- a/lib/types/dashboard.ts
+++ b/lib/types/dashboard.ts
@@ -26,6 +26,7 @@ export interface GroupedProviderTimelines {
   displayName: string; // 显示名称（未分组为 "未分组"）
   timelines: ProviderTimeline[];
   websiteUrl?: string | null; // 网站地址
+  tags?: string[] | null; // 分组标签
 }
 
 /**

--- a/lib/types/database.ts
+++ b/lib/types/database.ts
@@ -41,6 +41,7 @@ export interface GroupInfoRow {
   id: string;
   group_name: string;
   website_url?: string | null;
+  tags?: string[] | null;
   created_at?: string;
   updated_at?: string;
 }

--- a/supabase/migrations/20260108120000_add_group_tags.sql
+++ b/supabase/migrations/20260108120000_add_group_tags.sql
@@ -1,0 +1,5 @@
+ALTER TABLE public.group_info
+ADD COLUMN IF NOT EXISTS tags text[] NOT NULL DEFAULT '{}'::text[];
+
+COMMENT ON COLUMN public.group_info.tags IS '分组标签，用于标记分组类型/用途';
+

--- a/supabase/schema-dev.sql
+++ b/supabase/schema-dev.sql
@@ -58,6 +58,7 @@ CREATE TABLE dev.group_info (
     id uuid NOT NULL DEFAULT gen_random_uuid(),
     group_name text NOT NULL,
     website_url text,
+    tags text[] NOT NULL DEFAULT '{}'::text[],
     created_at timestamp with time zone DEFAULT now(),
     updated_at timestamp with time zone DEFAULT now(),
     CONSTRAINT group_info_pkey PRIMARY KEY (id),
@@ -154,6 +155,7 @@ COMMENT ON COLUMN dev.check_history.config_id IS '配置 UUID - 关联 check_con
 
 COMMENT ON COLUMN dev.group_info.group_name IS '分组名称 - 关联 check_configs.group_name';
 COMMENT ON COLUMN dev.group_info.website_url IS '网站地址';
+COMMENT ON COLUMN dev.group_info.tags IS '分组标签，用于标记分组类型/用途';
 
 COMMENT ON COLUMN dev.system_notifications.id IS '通知 UUID';
 COMMENT ON COLUMN dev.system_notifications.message IS '通知内容，支持 Markdown';

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -75,6 +75,7 @@ CREATE TABLE public.group_info (
     id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     group_name  text NOT NULL UNIQUE,
     website_url text,
+    tags        text[] NOT NULL DEFAULT '{}'::text[],
     created_at  timestamptz DEFAULT now(),
     updated_at  timestamptz DEFAULT now()
 );
@@ -82,6 +83,7 @@ CREATE TABLE public.group_info (
 COMMENT ON TABLE public.group_info IS '分组信息表';
 COMMENT ON COLUMN public.group_info.group_name IS '分组名称，关联 check_configs.group_name';
 COMMENT ON COLUMN public.group_info.website_url IS '网站地址';
+COMMENT ON COLUMN public.group_info.tags IS '分组标签，用于标记分组类型/用途';
 
 -- 系统通知表：存储全局系统通知
 CREATE TABLE public.system_notifications (


### PR DESCRIPTION
## What
Adds first-class tags to groups and renders them as badges in both the main dashboard and the group detail page.

## Changes Made
- Database: add `tags text[] NOT NULL DEFAULT '{}'` to `public.group_info` (plus dev schema), with a new migration.
- Types: extend `GroupInfoRow`, `GroupedProviderTimelines`, and `GroupDashboardData` to include `tags`.
- Data aggregation: plumb `group_info.tags` into grouped dashboard payloads.
- UI: show group tags as `Badge` pills next to the group title (dashboard group panel + group detail header), hidden when empty.

## Why
The task context is to tag groups (e.g. “公益站”, “商业站”) without encoding that meaning into the group name itself. Tags make the intent visible and searchable later, while keeping existing grouping behavior unchanged.

## Implementation Details
- Uses an array column (`text[]`) to support multiple tags per group.
- Defaults to an empty array to avoid null/special-case handling and to preserve backward compatibility.
- No public write endpoint was added; tags remain managed via Supabase/DB to avoid expanding the RLS/write surface area.

## Migration Notes
After applying migrations, you can set tags with:
```sql
INSERT INTO public.group_info (group_name, tags)
VALUES ('<group_name>', ARRAY['公益站','商业站'])
ON CONFLICT (group_name)
DO UPDATE SET tags = EXCLUDED.tags;
```

This PR was written using [Vibe Kanban](https://vibekanban.com)
