### PR TITLE
style: 调整标签颜色数组顺序

### DIFF
--- a/lib/utils/tag-colors.ts
+++ b/lib/utils/tag-colors.ts
@@ -12,11 +12,11 @@ export const parseTagList = (tags?: string | null): string[] => {
 const TAG_COLOR_CLASSES = [
   "bg-sky-100 text-sky-700 dark:bg-sky-500/15 dark:text-sky-400",
   "bg-violet-100 text-violet-700 dark:bg-violet-500/15 dark:text-violet-400",
-  "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-400",
-  "bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-400",
-  "bg-rose-100 text-rose-700 dark:bg-rose-500/15 dark:text-rose-400",
-  "bg-cyan-100 text-cyan-700 dark:bg-cyan-500/15 dark:text-cyan-400",
   "bg-indigo-100 text-indigo-700 dark:bg-indigo-500/15 dark:text-indigo-400",
+  "bg-rose-100 text-rose-700 dark:bg-rose-500/15 dark:text-rose-400",
+  "bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-400", // "商业"
+  "bg-cyan-100 text-cyan-700 dark:bg-cyan-500/15 dark:text-cyan-400",
+  "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-400", // "公益"
   "bg-lime-100 text-lime-700 dark:bg-lime-500/15 dark:text-lime-400",
 ];
 


### PR DESCRIPTION
重新排列 `TAG_COLOR_CLASSES` 数组，使 hash 算法对常见标签产生更合适的颜色：
   - "公益" → emerald (翠绿色)
   - "商业" → amber (琥珀色)

> 个人觉得现在 “商业” 展示的红色会让人在打开页面后有一种 “都是报错/不可用” 的感觉，所以换一个或许会更好一点（？）一个小小的建议