### PR TITLE
feat: 非自定义排序模式下，禁用拖拽排序

### DIFF
--- a/components/dashboard-view.tsx
+++ b/components/dashboard-view.tsx
@@ -502,7 +502,10 @@ export function DashboardView({ initialData }: DashboardViewProps) {
 
   // Filter and sort groups based on search query and sort mode
   const filteredGroupNames = useMemo(() => {
-    let result = orderedGroupNames;
+    let result =
+      sortMode === "custom"
+        ? orderedGroupNames
+        : groupedTimelines.map((g) => g.groupName);
 
     // Filter by search query
     if (searchQuery.trim()) {


### PR DESCRIPTION
仅 “自定义” 模式时支持拖拽排序，避免 UX 逻辑混乱