### PR TITLE
fix: add instrumentation.ts to initialize poller in Docker standalone mode

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,11 @@
+/**
+ * Next.js Instrumentation Hook
+ * 在服务器启动时初始化后台轮询器
+ * 修复 Docker standalone 模式下轮询器无法启动的问题
+ * @see https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation
+ */
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    await import('@/lib/core/poller')
+  }
+}


### PR DESCRIPTION
## 问题

在 Docker standalone 模式下，模型检测轮询器永远不会启动，导致 `check_history` 没有记录，前端时间线一直为空。

**根本原因**：轮询器通过 `app/layout.tsx` 的 `import "@/lib/core/poller"` 初始化，但 Next.js standalone 模式下主页面是静态预渲染（SSG）的，`layout.tsx` 在运行时从不执行，`setInterval` 计时器永远不会被创建。

可通过日志确认：容器启动后，`[官方状态]` 轮询器正常运行，但 `[check-cx] 初始化后台轮询器` 这条日志从不出现。

## 修复

在项目根目录添加 `instrumentation.ts`，利用 Next.js 官方服务器启动钩子（适用于所有部署场景）在服务器启动时初始化轮询器。

## 测试

 已在 Docker standalone 环境验证：
- 容器启动后日志出现 `[check-cx] 初始化后台轮询器`
- `check_history` 表每 60 秒正常写入检测记录
- 前端 Dashboard 正常显示监控卡片

Closes #29