### PR TITLE
docs: add deployment shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,52 @@ Dashboard 与只读状态 API，适用于团队内部状态展示、供应商 SL
 
 ![Check CX Dashboard](docs/images/index.png)
 
+## 一键部署 / 快速入口
+
+### Vercel
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fxingxinag%2Fcheck-cx&project-name=check-cx&repository-name=check-cx)
+
+适配情况：
+
+- 仓库已有 `vercel.json`
+- 项目是标准 `Next.js` 应用
+- 需要在 Vercel 环境变量中填写下方“环境变量”章节的 `SUPABASE_*` 等配置
+
+### Railway
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new/template?template=https%3A%2F%2Fgithub.com%2Fxingxinag%2Fcheck-cx)
+
+适配情况：
+
+- 仓库已有 `Dockerfile`
+- Railway 可按 Dockerfile 构建运行
+- 需要在 Railway Variables 中填写下方“环境变量”章节的配置
+
+### Docker / 自建服务器
+
+```bash
+docker compose up -d
+```
+
+适配情况：
+
+- 仓库已有 `Dockerfile`
+- 仓库已有 `docker-compose.yml`
+- 默认镜像为 `bingzi233/check-cx:latest`
+- 需要准备 `.env` 文件，内容可参考 `.env.example`
+
+### 其他平台支持情况
+
+| 平台 | 状态 | 说明 |
+|------|------|------|
+| Vercel | 推荐 | 原生支持 Next.js，仓库已有 `vercel.json` |
+| Docker / 自建服务器 | 推荐 | 仓库已有 `Dockerfile` 和 `docker-compose.yml` |
+| Railway | 可用 | 可基于 Dockerfile 部署 |
+| Render | 理论可用 | 可按 Docker Web Service 部署，但仓库暂无 `render.yaml` 一键配置 |
+| Netlify | 不推荐 | 仓库暂无 `netlify.toml`，且后台轮询更适合 Node 服务端运行 |
+| Cloudflare Pages | 不推荐 | 仓库暂无 OpenNext/Workers 适配配置，后台轮询与 service role 更适合 Node/Docker/Vercel |
+
 ## 功能概览
 
 - 统一的 Provider 健康检查能力（OpenAI / Gemini / Anthropic），支持 Chat Completions 与 Responses 端点


### PR DESCRIPTION
## Summary
- Add Vercel and Railway deployment shortcut buttons to the README.
- Document Docker/self-hosted startup and platform support notes.
- Clarify why Netlify and Cloudflare Pages are not recommended for this app's current runtime model.

## Test Plan
- Verified README diff only changes deployment documentation.
- Ran `git diff --check` before committing.